### PR TITLE
Check for nil to avoid crashing if the user doesn't have the italic font installed.

### DIFF
--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -91,7 +91,7 @@ public class Theme {
         
         boldCodeFont = RPFont(descriptor: boldDescriptor, size: font.pointSize)
         italicCodeFont = RPFont(descriptor: italicDescriptor, size: font.pointSize)
-        if(italicCodeFont.familyName != font.familyName)
+        if(italicCodeFont == nil || italicCodeFont.familyName != font.familyName)
         {
             italicCodeFont = RPFont(descriptor: obliqueDescriptor, size: font.pointSize)
         }


### PR DESCRIPTION
This could be cleaned up using ?? and defaulting to a system font or the codeFont instead. I just added the nil check to get going quickly.