### PR TITLE
Fix html render crash in non-fastRender && adjust access level

### DIFF
--- a/Pod/Classes/Highlightr.swift
+++ b/Pod/Classes/Highlightr.swift
@@ -129,7 +129,8 @@ open class Highlightr
              ]
             
             let data = string.data(using: String.Encoding.utf8)!
-            safeMainSync {
+            safeMainSync
+            {
                 returnString = try? NSMutableAttributedString(data:data, options: opt, documentAttributes:nil)
             }
         }
@@ -170,9 +171,11 @@ open class Highlightr
      Execute block safely on main thread, execute block directly if current thread is main thread, otherwise execute block on main queue synchronously.
      */
     private func safeMainSync(_ block: @escaping ()->()) {
-        if Thread.isMainThread {
+        if Thread.isMainThread
+        {
             block()
-        } else {
+        }else
+        {
             DispatchQueue.main.sync { block() }
         }
     }

--- a/Pod/Classes/Highlightr.swift
+++ b/Pod/Classes/Highlightr.swift
@@ -170,7 +170,8 @@ open class Highlightr
     /**
      Execute block safely on main thread, execute block directly if current thread is main thread, otherwise execute block on main queue synchronously.
      */
-    private func safeMainSync(_ block: @escaping ()->()) {
+    private func safeMainSync(_ block: @escaping ()->())
+    {
         if Thread.isMainThread
         {
             block()

--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -38,8 +38,8 @@ open class Theme {
     /// Italic font to be used by this theme
     open var italicCodeFont : RPFont!
     
-    fileprivate var themeDict : RPThemeDict!
-    fileprivate var strippedTheme : RPThemeStringDict!
+    private var themeDict : RPThemeDict!
+    private var strippedTheme : RPThemeStringDict!
     
     /// Default background color for the current theme.
     open var themeBackgroundColor : RPColor!
@@ -157,7 +157,7 @@ open class Theme {
         return returnString
     }
     
-    fileprivate func stripTheme(_ themeString : String) -> [String:[String:String]]
+    private func stripTheme(_ themeString : String) -> [String:[String:String]]
     {
         let objcString = (themeString as NSString)
         let cssRegex = try! NSRegularExpression(pattern: "(?:(\\.[a-zA-Z0-9\\-_]*(?:[, ]\\.[a-zA-Z0-9\\-_]*)*)\\{([^\\}]*?)\\})", options:[.caseInsensitive])
@@ -213,7 +213,7 @@ open class Theme {
         return returnDict
     }
     
-    fileprivate func strippedThemeToString(_ theme: RPThemeStringDict) -> String
+    private func strippedThemeToString(_ theme: RPThemeStringDict) -> String
     {
         var resultString = ""
         for (key, props) in theme {
@@ -230,7 +230,7 @@ open class Theme {
         return resultString
     }
     
-    fileprivate func strippedThemeToTheme(_ theme: RPThemeStringDict) -> RPThemeDict
+    private func strippedThemeToTheme(_ theme: RPThemeStringDict) -> RPThemeDict
     {
         var returnTheme = RPThemeDict()
         for (className, props) in theme
@@ -265,7 +265,7 @@ open class Theme {
         return returnTheme
     }
     
-    fileprivate func fontForCSSStyle(_ fontStyle:String) -> RPFont
+    private func fontForCSSStyle(_ fontStyle:String) -> RPFont
     {
         switch fontStyle
         {
@@ -278,7 +278,7 @@ open class Theme {
         }
     }
     
-    fileprivate func attributeForCSSKey(_ key: String) -> NSAttributedStringKey
+    private func attributeForCSSKey(_ key: String) -> NSAttributedStringKey
     {
         switch key {
         case "color":
@@ -294,7 +294,7 @@ open class Theme {
         }
     }
     
-    fileprivate func colorWithHexString (_ hex:String) -> RPColor
+    private func colorWithHexString (_ hex:String) -> RPColor
     {
 
         var cString:String = hex.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)


### PR DESCRIPTION
1. Fix html render crash in non-fastRender, we should use `String.Encoding.utf8.rawValue` when create `opt`, and render html in attributeString in main thread.
2. Adjust access level, use `private` instead of `fileprivate`.