### PR TITLE
Init stringStorage as NSTextStorage in CodeAttributedString

### DIFF
--- a/Pod/Classes/CodeAttributedString.swift
+++ b/Pod/Classes/CodeAttributedString.swift
@@ -33,7 +33,7 @@ import Foundation
 open class CodeAttributedString : NSTextStorage
 {
     /// Internal Storage
-    let stringStorage = NSMutableAttributedString(string: "")
+    let stringStorage = NSTextStorage()
 
     /// Highlightr instace used internally for highlighting. Use this for configuring the theme.
     open let highlightr = Highlightr()!


### PR DESCRIPTION
When I used CodeAttributedString, my app crashed due to memory leak for large files.
I tested with the demo project also, I put long code, and the app crashed.

I searched a solution, and I found this [answer](https://stackoverflow.com/a/37953430/7515957).
It's worked! 
I replaced:
```swift
let stringStorage = NSMutableAttributedString(string: "")
```
with:
```swift
let stringStorage = NSTextStorage()
```
