### PR TITLE
Support iOS8

### DIFF
--- a/Highlightr.xcodeproj/project.pbxproj
+++ b/Highlightr.xcodeproj/project.pbxproj
@@ -1919,6 +1919,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Highlightr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.raspu.Highlightr;
 				PRODUCT_NAME = Highlightr;
@@ -1942,6 +1943,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Highlightr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.raspu.Highlightr;
 				PRODUCT_NAME = Highlightr;


### PR DESCRIPTION
Currently the minimum supported version defaults to 10.3. Actually the project is compatible down to iOS8 (lowest supported by Xcode 9). This PR changes the project minimum supported version to iOS8, so it can be used in projects still targeting those OS's.