### PR TITLE
Don't error when an italic font doesn't exist

### DIFF
--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -112,7 +112,8 @@ open class Theme {
         if(italicCodeFont == nil || italicCodeFont.familyName != font.familyName)
         {
             italicCodeFont = RPFont(descriptor: obliqueDescriptor, size: font.pointSize)
-        } else if(italicCodeFont == nil )
+        }
+        if(italicCodeFont == nil)
         {
             italicCodeFont = font
         }


### PR DESCRIPTION
This makes a tiny fix so that it checks for `nil` even if the oblique font has already been used as a fallback. This is useful for fonts without italics (i.e. [Fira Code](https://github.com/tonsky/FiraCode))