### PR TITLE
Added public modifier to Theme initializer

### DIFF
--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -49,7 +49,7 @@ open class Theme {
      
      - parameter themeString: Theme to use.
      */
-    init(themeString: String)
+    public init(themeString: String)
     {
         theme = themeString
         setCodeFont(RPFont(name: "Courier", size: 14)!)


### PR DESCRIPTION
Currently the Theme initializer `init(themeString: String)` was set to `internal`.
Making the initializer `public` allows developers to inject custom CSS Highlightr Code.

```swift
let customHighlightrCSS = "......."
let customTheme = Theme(themeString: customHighlightrCSS)

let highlightr = Highlightr()
highlightr?.theme = customTheme
```