### PR TITLE
Wrong colors when highlights functions and classes

### DIFF
--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -139,6 +139,16 @@ open class Theme {
             attrs[.font] = codeFont
             for style in styleList
             {
+                var style = style
+
+                if styleList.contains("hljs-title") && styleList.contains("hljs-function") && themeDict["hljs-function-hljs-title"] != nil {
+                    style = "hljs-function-hljs-title"
+                }
+
+                if styleList.contains("hljs-title") && styleList.contains("hljs-class") {
+                    style = "hljs-class-hljs-title"
+                }
+
                 if let themeStyle = themeDict[style] as? [AttributedStringKey: Any]
                 {
                     for (attrName, attrValue) in themeStyle
@@ -197,6 +207,15 @@ open class Theme {
         {
             let keyArray = keys.replacingOccurrences(of: " ", with: ",").components(separatedBy: ",")
             for key in keyArray {
+                var key = key
+                if keyArray.contains(".hljs-title") && keyArray.contains(".hljs-function") {
+                    key = "hljs-function-hljs-title"
+                }
+
+                if keyArray.contains(".hljs-title") && keyArray.contains(".hljs-class") {
+                    key = "hljs-class-hljs-title"
+                }
+
                 var props : [String:String]?
                 props = returnDict[key]
                 if props == nil {

--- a/Pod/Classes/Theme.swift
+++ b/Pod/Classes/Theme.swift
@@ -145,7 +145,7 @@ open class Theme {
                     style = "hljs-function-hljs-title"
                 }
 
-                if styleList.contains("hljs-title") && styleList.contains("hljs-class") {
+                if styleList.contains("hljs-title") && styleList.contains("hljs-class") && themeDict["hljs-class-hljs-title"] != nil {
                     style = "hljs-class-hljs-title"
                 }
 


### PR DESCRIPTION
Bug filled by FSNotes user here https://github.com/glushchenko/fsnotes/issues/1269

After classes parsing in span, colors not depend from only one hljs-title, hljs-class and hljs-function changes colors by css too.

Pull request fixes it.