### PR TITLE
Updated-Build-Settings-To-Support-Active-Architecture

### DIFF
--- a/Highlightr.xcodeproj/project.pbxproj
+++ b/Highlightr.xcodeproj/project.pbxproj
@@ -886,6 +886,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.raspu.Highlightr;
 				PRODUCT_NAME = Highlightr;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -911,6 +912,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.raspu.Highlightr;
 				PRODUCT_NAME = Highlightr;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Highlightr.xcodeproj/project.pbxproj
+++ b/Highlightr.xcodeproj/project.pbxproj
@@ -935,6 +935,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.raspu.Highlightr-macOS";
 				PRODUCT_NAME = Highlightr;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -960,6 +961,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.raspu.Highlightr-macOS";
 				PRODUCT_NAME = Highlightr;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
This is aimed at fixing the issue, when using this on an Apple Silicon mac.

```
Build failed because Highlightr.swiftmodule is not built for arm64. Please try a run destination with a different architecture.
```